### PR TITLE
Remove share buttons on product page

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -264,7 +264,6 @@
     </script>
     <script src="{{ theme | theme_js_url }}"></script>
     {% if page.full_url contains '/product/' %}
-      <script async defer src="//assets.pinterest.com/js/pinit.js"></script>
       <script>
         var show_sold_out_product_options = '{{ theme.show_sold_out_product_options }}';
         Product.find('{{ product.permalink }}', processProduct)

--- a/source/product.html
+++ b/source/product.html
@@ -183,14 +183,5 @@
     {% if product.description != blank %}
       <div class="product-detail__description">{{ product.description | paragraphs }}</div>
     {% endif %}
-    {% if theme.share_buttons %}
-      {% capture tweet_string %}{{ product.name }} - {{ store.name }} {{ page.full_url }}{% endcapture %}
-      {% assign tweet_string = tweet_string | url_encode %}
-      <ul class="sharing">
-        <li><a target="_blank" href="https://twitter.com/intent/tweet?text={{ tweet_string }}">Tweet</a></li>
-        <li><a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u={{store.url}}{{product.url}}">Share</a></li>
-        <li><a target="_blank" data-pin-custom="true" data-pin-do="buttonPin" href="https://www.pinterest.com/pin/create/button/?url={{ page.full_url }}&media={{ product.images.first.url }}&description={{ product.description | escape }}">Pin</a></li>
-      </ul>
-    {% endif %}
   </section>
 </div>

--- a/source/settings.json
+++ b/source/settings.json
@@ -255,13 +255,6 @@
       "description": "The arrangement of your products on the Home and Products pages"
     },
     {
-      "variable": "share_buttons",
-      "label": "Show social buttons",
-      "type": "boolean",
-      "default": false,
-      "description": "Adds Facebook, Twitter, and Pinterest buttons to Product pages"
-    },
-    {
       "variable": "show_sold_out_product_options",
       "label": "Show sold out product options",
       "type": "boolean",

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -80,29 +80,3 @@
 
 #instant-checkout-button
   margin-top: 12px
-
-.sharing
-  display: flex
-  align-items: center
-  justify-content: flex-start
-  gap: 12px
-  color: var(--primary-color)
-  font-weight: bold
-
-  li
-    position: relative
-
-    &:after
-      content: ''
-      height: calc(100% - 8px)
-      top: 4px
-      position: absolute
-      width: 2px
-      background: var(--primary-color)
-
-    a
-      margin-right: 12px
-
-    &:last-child
-      &:after
-        display: none


### PR DESCRIPTION
Engagement on these types of Share buttons continues to decrease year over year, so the buttons are being removed. Instead, visitors can copy/paste URLs, use browser plugins, or use the native share tools on mobile browsers.